### PR TITLE
[PI-30989] Package 내 의존성 업그레이드 

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Alamofire/Alamofire.git",
         "state": {
           "branch": null,
-          "revision": "0c8cb78d05b6d067ee331c05058ff4dedcb45ffa",
-          "version": "5.0.0"
+          "revision": "354dda32d89fc8cd4f5c46487f64957d355f53d8",
+          "version": "5.6.1"
         }
       },
       {
@@ -24,17 +24,17 @@
         "repositoryURL": "https://github.com/Moya/Moya.git",
         "state": {
           "branch": null,
-          "revision": "b3e5a233e0d85fd4d69f561c80988590859c7dee",
-          "version": "14.0.0"
+          "revision": "9b906860e3c3c09032879465c471e6375829593f",
+          "version": "15.0.0"
         }
       },
       {
         "package": "ReactiveSwift",
-        "repositoryURL": "https://github.com/Moya/ReactiveSwift.git",
+        "repositoryURL": "https://github.com/ReactiveCocoa/ReactiveSwift.git",
         "state": {
           "branch": null,
-          "revision": "f195d82bb30e412e70446e2b4a77e1b514099e88",
-          "version": "6.1.0"
+          "revision": "c43bae3dac73fdd3cb906bd5a1914686ca71ed3c",
+          "version": "6.7.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
         "state": {
           "branch": null,
-          "revision": "b3e888b4972d9bc76495dd74d30a8c7fad4b9395",
-          "version": "5.0.1"
+          "revision": "b4307ba0b6425c0ba4178e138799946c3da594f8",
+          "version": "6.5.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -7,14 +7,14 @@ let shouldTest = ProcessInfo.processInfo.environment["TEST_MM"] == "1"
 
 func resolveDependencies() -> [Package.Dependency] {
     let baseDependencies: [Package.Dependency] = [
-        .package(url: "https://github.com/Moya/Moya.git", .upToNextMajor(from: "14.0.0")),
+        .package(url: "https://github.com/Moya/Moya.git", .upToNextMajor(from: "15.0.0")),
         .package(url: "https://github.com/lyft/mapper.git", .upToNextMajor(from: "10.0.0"))
     ]
 
     if shouldTest {
         let testDependencies: [Package.Dependency] = [
-            .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "2.0.0")),
-            .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "8.0.0"))
+            .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "5.0.0")),
+            .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.0.0"))
         ]
 
         return baseDependencies + testDependencies


### PR DESCRIPTION

아래 의존성 이슈를 해결하기 위해 Moya 버전 업그레이드함
Quick, Nimble도 너무 낮은 버전을 의존하고 있어서 충돌이 예상되어 업데이트함 
```
xcodebuild: error: Could not resolve package dependencies:
  Dependencies could not be resolved because root depends on 'rxswift' 6.0.0..<7.0.0 and root depends on 'moya' 14.0.0..<15.0.0.
'moya' 14.0.0..<15.0.0 practically depends on 'rxswift' 5.0.0..<6.0.0 because 'moya' 14.0.0 depends on 'rxswift' 5.0.0..<6.0.0 and 'moya' 14.0.1 depends on 'rxswift' 5.0.0..<6.0.0.
'moya' {14.0.0, 14.0.2..<15.0.0} practically depends on 'rxswift' 5.0.0..<6.0.0 because no versions of 'moya' match the requirement 14.0.2..<15.0.0 and 'moya' 14.0.0 depends on 'rxswift' 5.0.0..<6.0.0.
```

Moya, Quict, Nimble 의존성이 낮은 상황이라, root 프로젝트에서 사용하는 의존성과 충돌나지 않게 업데이트함.



PI-30989